### PR TITLE
fix: don't call flush() in every iteration

### DIFF
--- a/db/Fixtures/UserFixture.php
+++ b/db/Fixtures/UserFixture.php
@@ -28,8 +28,8 @@ class UserFixture extends AbstractFixture
 			$entity->setRole($user['role']);
 
 			$manager->persist($entity);
-			$manager->flush();
 		}
+		$manager->flush();
 	}
 
 	/**


### PR DESCRIPTION
Calling flush() only once so all users are inserted in one transaction. Similar to contributte/apitte-skeleton#261