### PR TITLE
Move scripts from Makefile to composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,22 @@
 .PHONY: qa cs cfx phpstan tests build
 
-qa: cs phpstan
+qa:
+	composer qa
 
 cs:
-	vendor/bin/codesniffer app tests
+	composer cs
 
 cfx:
-	vendor/bin/codefixer app tests
+	composer cfx
 
 phpstan:
-	vendor/bin/phpstan analyse -l max -c phpstan.neon --memory-limit=512M app tests/toolkit
+	composer phpstan
 
 tests:
-	vendor/bin/tester -s -p php --colors 1 -C tests
+	composer tests
 
 tests-coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	composer tests-coverage
 
 #####################
 # LOCAL DEVELOPMENT #

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,25 @@
 		],
 		"post-update-cmd": [
 			"Contributte\\Neonizer\\NeonizerExtension::process"
+		],
+		"qa": [
+			"composer cs",
+			"composer phpstan"
+		],
+		"cs": [
+			"vendor/bin/codesniffer app tests"
+		],
+		"cfx": [
+			"vendor/bin/codefixer app tests"
+		],
+		"tests": [
+			"vendor/bin/tester -s -p php --colors 1 -C tests"
+		],
+		"tests-coverage": [
+			"vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests"
+		],
+		"phpstan": [
+			"vendor/bin/phpstan analyse -l max -c phpstan.neon --memory-limit=512M app tests/toolkit"
 		]
 	},
 	"extra": {


### PR DESCRIPTION
Motivation: 
1) make utility is usually not included in PHP docker images
2) Why use make if I can do the same with composer
3) npm/yarn does it the same way