### PR TITLE
Fixed: Nettrine mirations config

### DIFF
--- a/config/ext/nettrine.neon
+++ b/config/ext/nettrine.neon
@@ -42,8 +42,8 @@ nettrine.orm.annotations:
 nettrine.migrations:
 	table: doctrine_migrations
 	column: version
-	directory: %rootDir%/db/Migrations
-	namespace: Database\Migrations
+	directories:
+		Database\Migrations: %rootDir%/db/Migrations
 	versionsOrganization: null
 
 nettrine.fixtures:


### PR DESCRIPTION
Update configuration for nettrine.migrations. When creating a project via Composer, the latest versions are downloaded, and the old syntax is not allowed.

https://github.com/contributte/doctrine-migrations/tree/master/.docs#minimal-configuration