### PR TITLE
CI: switch coverage reporting to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,7 +13,30 @@ on:
 jobs:
   coverage:
     name: "Coverage"
-    uses: contributte/.github/.github/workflows/phpunit-coverage.yml@v1
-    with:
-      php: "8.4"
-      make: "init coverage"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "PHP"
+        uses: "contributte/.github/.github/actions/setup-php@master"
+        with:
+          php: "8.4"
+
+      - name: "Composer"
+        uses: "contributte/.github/.github/actions/setup-composer@master"
+        with:
+          command: "composer install --no-interaction --no-progress --prefer-dist"
+
+      - name: "Run coverage"
+        run: "make init coverage"
+
+      - name: "Codecov"
+        uses: "codecov/codecov-action@v4"
+        with:
+          files: "./coverage.xml"
+          fail_ci_if_error: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/webapp-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/webapp-skeleton/master"></a>
-  <a href="https://coveralls.io/r/contributte/webapp-skeleton"><img src="https://badgen.net/coveralls/c/github/contributte/webapp-skeleton"></a>
+  <a href="https://codecov.io/gh/contributte/webapp-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/webapp-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/webapp-skeleton"><img src="https://badgen.net/packagist/dm/contributte/webapp-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/webapp-skeleton"><img src="https://badgen.net/packagist/v/contributte/webapp-skeleton"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## Summary
- replace the README Coveralls badge with Codecov
- switch the coverage workflow from the old shared Coveralls upload to a direct Codecov upload
- remove the obsolete tests/.coveralls.yml file

## Related
- contributte/contributte#72