### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Replace the `coverage` Makefile target to run Tester with `php` instead of `phpdbg`.

## Motivation

This aligns the skeleton with the org-wide migration tracked in contributte/contributte#73 and keeps new coverage runs compatible with the shared CI PHP setup.

## Changes

- switch `Makefile` coverage target from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification

Manual verification:
- `make coverage` now invokes `vendor/bin/tester -s -p php ...`
- local coverage execution is blocked in this environment because PHP lacks Xdebug/PCOV (`phpdbg` is no longer used)
- CI uses `contributte/.github/.github/actions/setup-php`, whose default `coverage` input is `xdebug`